### PR TITLE
Add function: translate label to index

### DIFF
--- a/src/globalConf.js
+++ b/src/globalConf.js
@@ -21,6 +21,7 @@ export const CONNECT_LIST = {
     "ASSEMBLY":"ASSEMBLY",
     "QC/TESTING":"QC/TESTING",
     "Close Safely?":"Close Safely?",
+    "Close Warning/Caution Reason":"Unsafe Closed Causes",
     "BOM Date":"BOM Updated Date",
     "Revised Part List Date":"Revised Part List Date",
     "isBOMChanged":"BOM Changed?"

--- a/src/modules/update/Update.js
+++ b/src/modules/update/Update.js
@@ -3,6 +3,36 @@ import { Button } from 'reactstrap'
 import { getBoardData } from './getBoardData' 
 import { getLocalDataWithConfiguration } from './getLocalData'
 import mondaySdk from "monday-sdk-js";
+import { extendWith } from 'lodash';
+
+/*
+Error handling for columns configuration
+Two type of error
+1. No column title
+2. No label in the column
+Write warning on the log (future implementation)
+Either error return null
+*/
+const getLabelsIndex = (configuration, columnTitle, labelData) => {
+    let targetConfLabels = null
+    for (const conf of configuration){
+        if (conf['title'] === columnTitle){
+            targetConfLabels = conf['labels']
+            break
+        }
+    }
+
+    if (!targetConfLabels) {
+        console.log(`There is no ${columnTitle} column on Monday`)
+        return null
+    }
+
+    return targetConfLabels[labelData] !== undefined ? targetConfLabels[labelData] : 
+    function(){
+        console.log(`There is no ${labelData} labels on ${columnTitle} column`)
+        return null
+    }() 
+}
 
 const getBaordIdList = (boardData) => {
     return Object.keys(boardData)
@@ -35,7 +65,7 @@ const getItemId = (localData, itemIds, configuration, boardData) => {
 const processItem = (localItem, itemIds, configuration, boardData) => {
     const localData = getLocalDataWithConfiguration(localItem, configuration)
     const id = getItemId(localData, itemIds, configuration, boardData)
-    if (id === null && getDataFromCsvTitle(localData, "Status") !== '19'){
+    if (id === null && getDataFromCsvTitle(localData, "Status") !== getLabelsIndex(configuration, "Status", "DONE")){
         console.log(id)
     } 
 

--- a/src/modules/update/Update.js
+++ b/src/modules/update/Update.js
@@ -6,6 +6,7 @@ import mondaySdk from "monday-sdk-js";
 import { extendWith } from 'lodash';
 
 /*
+Translate label to index with error handling
 Error handling for columns configuration
 Two type of error
 1. No column title


### PR DESCRIPTION
Translate label to index with error handling
Error handling for columns configuration
Two type of error
1. No column title
1. No label in the column

Write warning on the log (future implementation)
Either error return null